### PR TITLE
fix: add bevietnampro font style

### DIFF
--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@400;500;700&display=swap');
+
 @font-face {
   font-family: "Eurostile";
   src: url("./assets/fonts/Eurostile/SFUEurostileRegular.TTF");


### PR DESCRIPTION
# [FIX]: [Add Be Vietnam Pro font style]

## Description
### Briefly describe the purpose of this pull request.
- This pull request updates the project’s typography by adding Be Vietnam Pro – a Google Fonts reference – to properly display rich text from the Back Office (BO).

## Changes
### Outline the main changes made in this pull request.
- Added Google Fonts import for Be Vietnam Pro (weights 400, 500, 700).

### Include screenshots if there are any UI changes.
![Uploading image.png…]()

## Testing

- [x] Local
- [ ] Development Environment
